### PR TITLE
Allow apps with no EXTRA_ARGS

### DIFF
--- a/scripts/generate
+++ b/scripts/generate
@@ -7,4 +7,4 @@ set -ue
 # realpath's `-m` is required, since the path might not exist.
 ENV_DIR=$(realpath -m "environments/$ARGOCD_ENV_TK_ENV")
 
-tk show "$ENV_DIR" --dangerous-allow-redirect ${ARGOCD_ENV_EXTRA_ARGS}
+tk show "$ENV_DIR" --dangerous-allow-redirect ${ARGOCD_ENV_EXTRA_ARGS:-}


### PR DESCRIPTION
If the app needs no extra args like
```yaml
spec:
  source:
    plugin:
      env:
        - name: TK_ENV
          value: default
        # - name: EXTRA_ARGS
        #  value: --extra-options-you-need
```

the plugin crashes with unbound variable. This PR fixes the issue by rendering an empty string instead of crashing