### PR TITLE
Make discover not dependent on env vars

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -19,4 +19,7 @@ spec:
 
     discover:
         find:
-            command: ["bash", "-c", "/script-wrapper /discover"]
+            command:
+                - "bash"
+                - "-c"
+                - "find . -name jsonnetfile.json"

--- a/scripts/discover
+++ b/scripts/discover
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-find . -name 'jsonnetfile.json'


### PR DESCRIPTION
Sometimes `discover` is called without all the build time environment, so no ARGOCD_APP_NAME or ARGOCD_APP_REVISION are available, at least that's true on ArgoCD v2.10.1+a79e0ea.

On the other hand if all we do is to check for the presence of `jsonnetfile.json` somewhere, we can skip the wrapper entirely. That's what the PR does.